### PR TITLE
feat: --install flag + claude() wrapper

### DIFF
--- a/src/impl.ts
+++ b/src/impl.ts
@@ -14,31 +14,69 @@
 import { UserError } from "./internal/user-error";
 import { zshSnippet } from "./snippets/zsh";
 import { bashSnippet } from "./snippets/bash";
+import { readFileSync, writeFileSync, existsSync } from "fs";
+import { homedir } from "os";
+import { join } from "path";
 
 export const SUPPORTED_SHELLS = ["zsh", "bash"] as const;
 export type SupportedShell = (typeof SUPPORTED_SHELLS)[number];
 
-const HELP = `usage: maw shellenv <shell>
+const HELP = `usage: maw shellenv [<shell>] [--install]
 
 Emit shell init code for eval-style installation.
 
-  Install (zsh):
-    eval "$(maw shellenv zsh)"     # add to ~/.zshrc
+  Install (auto):
+    maw shellenv --install         # auto-detect $SHELL, append to rc file
 
-  Install (bash):
+  Install (manual):
+    eval "$(maw shellenv zsh)"     # add to ~/.zshrc
     eval "$(maw shellenv bash)"    # add to ~/.bashrc
 
 Available shells: ${SUPPORTED_SHELLS.join(", ")}
-(fish deferred to v2 — see #812)
 
-The emitted snippet installs a maw() function that adds:
-  maw warp [<oracle>]    cd into an oracle's repo (default: mawjs)
-  maw <other>            pass-through to the real binary
+The emitted snippet installs:
+  maw()    intercepts \`maw warp <oracle>\` (in-shell cd)
+  claude() auto-fallback when --continue fails (no prior session)
 
 `;
 
 export interface ShellenvOpts {
   help?: boolean;
+  install?: boolean;
+}
+
+const EVAL_LINE_PREFIX = 'eval "$(maw shellenv';
+
+function detectShell(): SupportedShell | null {
+  const shellEnv = process.env.SHELL || "";
+  if (shellEnv.endsWith("/zsh")) return "zsh";
+  if (shellEnv.endsWith("/bash")) return "bash";
+  return null;
+}
+
+function rcFileFor(shell: SupportedShell): string {
+  return join(homedir(), shell === "zsh" ? ".zshrc" : ".bashrc");
+}
+
+async function installToRc(shell: SupportedShell): Promise<void> {
+  const rc = rcFileFor(shell);
+  const evalLine = `eval "$(maw shellenv ${shell})"`;
+  const block = `\n# maw shellenv — auto-installed by 'maw shellenv --install'\n${evalLine}\n`;
+
+  if (existsSync(rc)) {
+    const content = readFileSync(rc, "utf-8");
+    if (content.includes(EVAL_LINE_PREFIX)) {
+      console.log(`\x1b[33m✓\x1b[0m already installed in ${rc}`);
+      console.log(`  Reload: \x1b[36msource ${rc}\x1b[0m`);
+      return;
+    }
+    writeFileSync(rc, content + block);
+  } else {
+    writeFileSync(rc, block);
+  }
+  console.log(`\x1b[32m✓\x1b[0m appended to ${rc}`);
+  console.log(`  Reload: \x1b[36msource ${rc}\x1b[0m`);
+  console.log(`  Or open a new terminal.`);
 }
 
 function emit(shell: SupportedShell): string {
@@ -60,6 +98,19 @@ export async function cmdShellenv(
 ): Promise<void> {
   if (opts.help) {
     console.log(HELP);
+    return;
+  }
+
+  // --install mode: auto-detect shell + append to rc file
+  if (opts.install) {
+    const detectedShell = shell && isSupported(shell) ? shell : detectShell();
+    if (!detectedShell) {
+      console.error(
+        `Error: could not detect shell from $SHELL='${process.env.SHELL || ""}'. Pass explicitly: maw shellenv <zsh|bash> --install`,
+      );
+      throw new UserError("could not detect shell");
+    }
+    await installToRc(detectedShell);
     return;
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
     {
       "--help": Boolean,
       "-h": "--help",
+      "--install": Boolean,
     },
     0,
   );
@@ -33,7 +34,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
     else logs.push(a.map(String).join(" "));
   };
   try {
-    await cmdShellenv(shell, { help: flags["--help"] });
+    await cmdShellenv(shell, { help: !!flags["--help"], install: !!flags["--install"] });
     return { ok: true, output: logs.join("\n") || undefined };
   } catch (e: unknown) {
     const msg = e instanceof Error ? e.message : String(e);

--- a/src/snippets/bash.ts
+++ b/src/snippets/bash.ts
@@ -29,6 +29,14 @@ maw() {
     command maw "$@"
   fi
 }
+# claude() wrapper — auto-fallback when --continue fails (no prior session).
+claude() {
+  if [[ "$*" == *"--continue"* ]]; then
+    command claude "$@" || command claude "\${@/--continue/}"
+  else
+    command claude "$@"
+  fi
+}
 # TODO(shellenv): tab completion for 'maw warp' via complete -F + 'command maw completions oracles'
 `;
 }

--- a/src/snippets/zsh.ts
+++ b/src/snippets/zsh.ts
@@ -32,6 +32,16 @@ maw() {
     command maw "$@"
   fi
 }
+# claude() wrapper — auto-fallback when --continue fails (no prior session).
+# Lets \`maw wake\` send a clean \`claude --dangerously-skip-permissions --continue\`
+# instead of a verbose \`{ X || Y; }\` fallback chain.
+claude() {
+  if [[ "$*" == *"--continue"* ]]; then
+    command claude "$@" || command claude "\${@/--continue/}"
+  else
+    command claude "$@"
+  fi
+}
 # TODO(shellenv): tab completion for 'maw warp' via compdef + 'command maw completions oracles'
 `;
 }


### PR DESCRIPTION
## Summary

Adds two ergonomic features:

### 1. `--install` flag (nvm-style)
```
maw shellenv --install                # auto-detect from \$SHELL
maw shellenv zsh --install            # explicit shell
```
Appends `eval "\$(maw shellenv zsh)"` to ~/.zshrc (or ~/.bashrc).  Idempotent — re-runs detect existing install.

### 2. `claude()` wrapper in emitted snippet
Auto-fallback when `claude --continue` fails (no prior session). Pairs with maw-js#1229 which simplifies buildCommand to emit a clean re-runnable command.

```zsh
claude() {
  if [[ "\$*" == *"--continue"* ]]; then
    command claude "\$@" || command claude "\${@/--continue/}"
  else
    command claude "\$@"
  fi
}
```

## Test plan
- [ ] `maw shellenv --install` on fresh ~/.zshrc appends correctly
- [ ] Second run is idempotent (no double-append)
- [ ] `source ~/.zshrc && type claude` shows the function
- [ ] `claude --continue` falls back to `claude` if no prior session

🤖 Generated with [Claude Code](https://claude.com/claude-code)